### PR TITLE
fix: set explicit PostgreSQL dialect to prevent Hibernate metadata qu…

### DIFF
--- a/bin/main/application-prod.properties
+++ b/bin/main/application-prod.properties
@@ -1,8 +1,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Production profile — activate with SPRING_PROFILES_ACTIVE=prod
 # Required Railway env vars (no defaults): SPRING_DATASOURCE_URL,
-#   SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD,
-#   APP_VERIFICATION_BASE_URL, SMTP_HOST, SMTP_USERNAME, SMTP_PASSWORD
+#   SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD
 # ─────────────────────────────────────────────────────────────────────────────
 
 # PostgreSQL — set SPRING_DATASOURCE_URL=jdbc:postgresql://<host>/<db> on Railway
@@ -18,7 +17,7 @@ spring.datasource.hikari.connection-timeout=30000
 spring.datasource.hikari.idle-timeout=600000
 spring.datasource.hikari.max-lifetime=1800000
 
-# Dialect is auto-detected; explicit setting triggers a deprecation warning in Hibernate 6
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 # Suppress open-in-view warning — lazy loading during view rendering is acceptable here
 spring.jpa.open-in-view=false
@@ -53,24 +52,3 @@ server.servlet.session.cookie.secure=true
 server.servlet.session.cookie.http-only=true
 server.servlet.session.cookie.same-site=strict
 
-# Email delivery — default smtp; set APP_EMAIL_PROVIDER=log to use log-only delivery
-app.email.provider=${APP_EMAIL_PROVIDER:smtp}
-app.email.from=${EMAIL_FROM:no-reply@jobtracker.app}
-
-# Verification link base URL — MUST match your Railway public domain
-# e.g. APP_VERIFICATION_BASE_URL=https://yourapp.up.railway.app
-app.verification.base-url=${APP_VERIFICATION_BASE_URL}
-
-# SMTP — required when APP_EMAIL_PROVIDER=smtp (the default)
-# If SMTP_HOST is unset and the provider is smtp the app will fail to start (by design).
-spring.mail.host=${SMTP_HOST:}
-spring.mail.port=${SMTP_PORT:587}
-spring.mail.username=${SMTP_USERNAME:}
-spring.mail.password=${SMTP_PASSWORD:}
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.starttls.required=true
-# Fail fast instead of hanging if the SMTP server is unreachable (ms)
-spring.mail.properties.mail.smtp.connectiontimeout=5000
-spring.mail.properties.mail.smtp.timeout=5000
-spring.mail.properties.mail.smtp.writetimeout=5000

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -17,7 +17,7 @@ spring.datasource.hikari.connection-timeout=30000
 spring.datasource.hikari.idle-timeout=600000
 spring.datasource.hikari.max-lifetime=1800000
 
-# Dialect is auto-detected; explicit setting triggers a deprecation warning in Hibernate 6
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 # Suppress open-in-view warning — lazy loading during view rendering is acceptable here
 spring.jpa.open-in-view=false


### PR DESCRIPTION
…ery failure on Railway

Without an explicit dialect, Hibernate queries the DB at startup to auto-detect it. On Railway this fails before the connection is ready, producing HHH000342.